### PR TITLE
Unpin pycrypto. Bump version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pycrypto==2.6
+pycrypto

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         pkg_name = '-'.join((pyver.replace('.', ''), pkg_name))
 
     setup(name=pkg_name,
-        version='0.1',
+        version='0.1.1',
         author='Demian Brecht',
         author_email='dbrecht@demonware.net',
         py_modules=['jose'],


### PR DESCRIPTION
Package versions in Python packages (especially libraries) should not be pinned down. Two specific reasons why `jose` shouldn't do it:
1. It doesn't look like it uses any specific functionality of version pycrypto 2.6. On the other hand it causes serious compatibility problems:
   `pkg_resources.VersionConflict: pycrypto 2.6.1 is installed but pycrypto==2.6 is required by ['jose']`
2. [pycrypto 2.6.1 fixes an important security bug](https://github.com/dlitz/pycrypto/blob/af058ee6f5da391a05275470ab4a4a96aa22b350/ChangeLog).

Please merge and upload new package to PyPI. Thanks :)
