### PR TITLE
Fix several issues with JWE encryption.

### DIFF
--- a/jose.py
+++ b/jose.py
@@ -146,9 +146,9 @@ def encrypt(claims, jwk, adata='', add_header=None, alg='RSA-OAEP',
     iv = rng(AES.block_size)
     encryption_key = rng(hash_mod.digest_size)
 
-    ciphertext = cipher(plaintext, encryption_key[:-hash_mod.digest_size], iv)
+    ciphertext = cipher(plaintext, encryption_key[-hash_mod.digest_size/2:], iv)
     hash = hash_fn(_jwe_hash_str(ciphertext, iv, adata),
-            encryption_key[-hash_mod.digest_size:], hash_mod)
+            encryption_key[:-hash_mod.digest_size/2], hash_mod)
 
     # cek encryption
     (cipher, _), _ = JWA[alg]
@@ -192,9 +192,9 @@ def decrypt(jwe, jwk, adata='', validate_claims=True, expiry_seconds=None):
     # decrypt body
     ((_, decipher), _), ((hash_fn, _), mod) = JWA[header['enc']]
 
-    plaintext = decipher(ciphertext, encryption_key[:-mod.digest_size], iv)
+    plaintext = decipher(ciphertext, encryption_key[-mod.digest_size/2:], iv)
     hash = hash_fn(_jwe_hash_str(ciphertext, iv, adata),
-            encryption_key[-mod.digest_size:], mod=mod)
+            encryption_key[:-mod.digest_size/2], mod=mod)
 
     if not const_compare(auth_tag(hash), tag):
         raise Error('Mismatched authentication tags')

--- a/jose.py
+++ b/jose.py
@@ -13,6 +13,7 @@ import datetime
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 from collections import namedtuple
 from time import time
+from struct import pack
 
 from Crypto.Hash import HMAC, SHA256, SHA384, SHA512
 from Crypto.Cipher import PKCS1_OAEP, AES
@@ -494,7 +495,7 @@ def _validate(claims, validate_claims, expiry_seconds):
 def _jwe_hash_str(plaintext, iv, adata=''):
     # http://tools.ietf.org/html/
     # draft-ietf-jose-json-web-algorithms-24#section-5.2.2.1
-    return '.'.join((adata, iv, plaintext, str(len(adata))))
+    return '.'.join((adata, iv, plaintext, pack("!Q", len(adata) * 8)))
 
 
 def _jws_hash_str(header, claims):

--- a/jose.py
+++ b/jose.py
@@ -144,7 +144,7 @@ def encrypt(claims, jwk, adata='', add_header=None, alg='RSA-OAEP',
     # body encryption/hash
     ((cipher, _), key_size), ((hash_fn, _), hash_mod) = JWA[enc]
     iv = rng(AES.block_size)
-    encryption_key = rng((key_size // 8) + hash_mod.digest_size)
+    encryption_key = rng(hash_mod.digest_size)
 
     ciphertext = cipher(plaintext, encryption_key[:-hash_mod.digest_size], iv)
     hash = hash_fn(_jwe_hash_str(ciphertext, iv, adata),


### PR DESCRIPTION
The issues, according to the [JWA spec](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-38#section-5.2.2.1) are:
* the **AL** field is not correctly calculated. It must represent the **length in bits** of the *additional authenticated data*, not in bytes. Additionally, it must be represented as an unsigned 64-bit octet string in big-endian, not as a simple string.

> 5.2.2.1.4.  The octet string AL is equal to the number of bits in the additional authenticated data A expressed as a 64-bit unsigned big endian integer.

* in order to compute the *authentication tag*, the **ciphertext** must be used, not the plaintext.

> 5.2.2.1.5.  A message authentication tag T is computed by applying HMAC [RFC2104] to the following data, in order:
> *         the additional authenticated data A,
> *         the initialization vector IV,
> *         the ciphertext E computed in the previous step, and
> *         the octet string AL defined above.

* in <tt>AES_CBC_HMAC_SHA2</tt>, the length of the input key equals to the digest size, that being 32, 48 and 64 octets for each of the three variants.

>The AES_CBC_HMAC_SHA2 parameters specific to AES_128_CBC_HMAC_SHA_256 are:
> *      The input key K is 32 octets long.
> *     ENC_KEY_LEN is 16 octets.
> *      MAC_KEY_LEN is 16 octets.

* the **integrity key** and **encryption key** are derived as the first and second half of the input key, respectively.

>The secondary keys MAC_KEY and ENC_KEY are generated from the input key K as follows.  Each of these two keys is an octet string.
*         MAC_KEY consists of the initial MAC_KEY_LEN octets of K, in order.
*         ENC_KEY consists of the final ENC_KEY_LEN octets of K, in order.

>The number of octets in the input key K MUST be the sum of MAC_KEY_LEN and ENC_KEY_LEN.  The values of these parameters are specified by the Authenticated Encryption algorithms in Sections 5.2.3 through 5.2.5.  Note that the MAC key comes before the encryption key in the input key K; this is in the opposite order of the algorithm names in the identifier "AES_CBC_HMAC_SHA2".