### PR TITLE
Bug in authentication tag computation

### DIFF
--- a/jose.py
+++ b/jose.py
@@ -209,7 +209,7 @@ def decrypt(jwe, jwk, adata='', validate_claims=True, expiry_seconds=None):
     # decrypt body
     ((_, decipher), _), ((hash_fn, _), mod) = JWA[header['enc']]
 
-    version = header.get(_TEMP_VER_KEY, None)
+    version = header.get(_TEMP_VER_KEY)
     if version:
         plaintext = decipher(ciphertext, encryption_key[-mod.digest_size/2:], iv)
         hash = hash_fn(_jwe_hash_str(ciphertext, iv, adata, version),

--- a/jose.py
+++ b/jose.py
@@ -57,7 +57,7 @@ CLAIM_JWT_ID = 'jti'
 # these are temporary to allow graceful deprecation of legacy encrypted tokens.
 # these will be removed in v1.0
 _TEMP_VER_KEY = '__v'
-_TEMP_VER = 1
+_TEMP_VER = 2
 
 
 class Error(Exception):
@@ -209,7 +209,7 @@ def decrypt(jwe, jwk, adata='', validate_claims=True, expiry_seconds=None):
     # decrypt body
     ((_, decipher), _), ((hash_fn, _), mod) = JWA[header['enc']]
 
-    if header.get(_TEMP_VER_KEY) == _TEMP_VER:
+    if header.get(_TEMP_VER_KEY) >= _TEMP_VER:
         plaintext = decipher(ciphertext, encryption_key[-mod.digest_size/2:], iv)
         hash = hash_fn(_jwe_hash_str(ciphertext, iv, adata),
                 encryption_key[:-mod.digest_size/2], mod=mod)
@@ -529,7 +529,7 @@ def _jwe_hash_str(ciphertext, iv, adata='', legacy=False):
     # draft-ietf-jose-json-web-algorithms-24#section-5.2.2.1
     if legacy:
         return '.'.join((adata, iv, ciphertext, str(len(adata))))
-    return '.'.join((adata, iv, ciphertext, pack("!Q", len(adata) * 8)))
+    return ''.join((adata, iv, ciphertext, pack("!Q", len(adata) * 8)))
 
 
 def _jws_hash_str(header, claims):

--- a/tests.py
+++ b/tests.py
@@ -276,8 +276,11 @@ class TestJWE(unittest.TestCase):
     def test_decrypt_invalid_compression_error(self):
         jwe = jose.encrypt(claims, rsa_pub_key, compression='DEF')
         header = jose.b64encode_url(
-            '{"alg": "RSA-OAEP", ''"enc": "A128CBC-HS256", "__v": 1,'
-            '"zip": "BAD"}')
+            jose.json_encode(
+                {"alg": "RSA-OAEP", "enc": "A128CBC-HS256",
+                 jose._TEMP_VER_KEY: jose._TEMP_VER, "zip": "BAD"}
+            )
+        )
 
         try:
             jose.decrypt(jose.JWE(*((header,) + (jwe[1:]))), rsa_priv_key)


### PR DESCRIPTION
There's a bug in the way the authentication tag is computed, running all tokens issued by the library undecipherable by other libraries, since they will always fail to check the token authentication if there's authenticated data (note that for *compact serialization*, the *header* should **always** be authenticated).

When computing the authentication tag, first we need to concatenate the data authenticated, the IV, the ciphertext and the length of the authenticated data in 64 bits big-endian. This is the input to the `HMAC` algorithm that yields the authentication tag. However, the values are concatenated in the `_jwe_hash_str()` method using a period between them, which is against [RFC7518](https://tools.ietf.org/html/rfc7518#section-5.2.2.1).

This PR addresses the problem by removing the period, using just an empty string as *glue* for the concatenation. In order to keep backwards compatibility and still be able to decrypt old tokens, the legacy mode of `_jwe_hash_str()` is kept as is. The temporary version number has been increased to `2`, so that all new tokens are encrypted with the correct authentication tag, while all the tokens issued before this change can still be identified and decrypted in *legacy* mode.