### PR TITLE
Interop / draft-ietf-jose-json-web-encryption-40

### DIFF
--- a/jose.py
+++ b/jose.py
@@ -213,7 +213,8 @@ def decrypt(jwe, jwk, adata='', validate_claims=True, expiry_seconds=None):
     # decrypt body
     ((_, decipher), _), ((hash_fn, _), mod) = JWA[header['enc']]
 
-    if header.get(_TEMP_VER_KEY) == _TEMP_VER:
+    if header.get(_TEMP_VER_KEY) == _TEMP_VER or \
+            len(encryption_key) == mod.digest_size:
         plaintext = decipher(ciphertext, encryption_key[-mod.digest_size/2:], iv)
         hash = hash_fn(_jwe_hash_str(ciphertext, iv, adata),
                 encryption_key[:-mod.digest_size/2], mod=mod)

--- a/jose.py
+++ b/jose.py
@@ -545,11 +545,11 @@ def _jwe_adata_str(adata, header):
 
 
 def _jwe_hash_str(ciphertext, iv, adata='', legacy=False):
-    # http://tools.ietf.org/html/
-    # draft-ietf-jose-json-web-algorithms-24#section-5.2.2.1
     if legacy:
         return '.'.join((adata, iv, ciphertext, str(len(adata))))
-    return '.'.join((adata, iv, ciphertext, pack("!Q", len(adata) * 8)))
+    # http://tools.ietf.org/html/
+    # draft-ietf-jose-json-web-algorithms-40#section-5.2.2.1
+    return ''.join((adata, iv, ciphertext, pack("!Q", len(adata) * 8)))
 
 
 def _jws_hash_str(header, claims):


### PR DESCRIPTION
I found some bugs preventing interop with a dot-NET client (https://github.com/dvsekhvalnov/jose-jwt).

For the relevant parts, I updated the Python implementation to what I read in draft -40, and that did the trick as far as interop with that particular other implementation required at least.
