### PR TITLE
Handled expiration exceptions during selection of decryption method.

### DIFF
--- a/jose.py
+++ b/jose.py
@@ -449,6 +449,11 @@ def decrypt(*args, **kwargs):
     """
     try:
         return legacy_decrypt(*args, **kwargs)
+    except (NotYetValid, Expired) as e:
+        # these should be raised immediately.
+        # The token has been decrypted successfully to get to here.
+        # decrypting using `legacy_decrypt` will not help things.
+        raise e
     except (Error, ValueError) as e:
         return spec_compliant_decrypt(*args, **kwargs)
 


### PR DESCRIPTION
`decrypt` chooses decrypt method (legacy or spec-compliant) using exceptions.
In this commit special treatment for failures due to expiration is added. If token decryption failed due to expiration we do not want to try the other decryption method. In addition we no longer miss expiration exceptions in such cases.