### PR TITLE
Fix: Handle JWT decryption correctly by deserializing compact format

### DIFF
--- a/jose.py
+++ b/jose.py
@@ -770,7 +770,7 @@ def _jws_hash_str(header, claims):
 
 
 def cli_decrypt(jwt, key):
-    print decrypt(deserialize_compact(jwt), {'k':key},
+    return decrypt(deserialize_compact(jwt), {'k':key},
         validate_claims=False)
 
 


### PR DESCRIPTION
Changed `print` to ` Replace print with return to
 resolve syntax error
